### PR TITLE
apiserver: Add missing http:// before master

### DIFF
--- a/roles/master/templates/apiserver.j2
+++ b/roles/master/templates/apiserver.j2
@@ -11,7 +11,7 @@ KUBE_API_ADDRESS="--address=0.0.0.0"
 KUBE_API_PORT="--port=8080"
 
 # How the replication controller and scheduler find the apiserver
-KUBE_MASTER="--master={{ groups['masters'][0] }}:8080"
+KUBE_MASTER="--master=http://{{ groups['masters'][0] }}:8080"
 
 # Comma seperated list of minions
 KUBELET_ADDRESSES="--machines={{ groups['minions']|join(',') }}"


### PR DESCRIPTION
This probably changed at some point, anyways it's definitely required
with kubernetes-0.8.0-125.0.git68298f0.el7.x86_64