### PR TITLE
Add variable to allow using hostnames for kubelets

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,3 +2,4 @@ ansible_ssh_user: root
 kube_service_addresses: 10.254.0.0/16
 kube_overlay_ip: 4.0.0.0
 kube_overlay_prefix: 16
+use_node_hostnames: False

--- a/roles/minion/templates/kubelet.j2
+++ b/roles/minion/templates/kubelet.j2
@@ -8,7 +8,11 @@ KUBELET_ADDRESS="--address={{ ansible_default_ipv4.address }}"
 KUBELET_PORT="--port=10250"
 
 # You may leave this blank to use the actual hostname
+{% if use_node_hostnames %}
+KUBELET_HOSTNAME=
+{% else %}
 KUBELET_HOSTNAME="--hostname_override={{ ansible_default_ipv4.address }}"
+{% endif %}
 
 # Add your own!
 KUBELET_ARGS=""


### PR DESCRIPTION
In my Vagrant setup, I'm writing /etc/hosts files for the master and
nodes.  And if the master uses hostnames, the nodes must also,
otherwise they'll try to look up their IP address in etcd for work and
find nothing.