### PR TITLE
Don't include RHEL7 tasks if using Atomic

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,7 +20,7 @@
   changed_when: false
 
 - include: rhel7_repos.yml
-  when: is_rhel7.rc == 0
+  when: is_rhel7.rc == 0 and not is_atomic
 
 - name: Determine if firewalld installed
   command: "rpm -q firewalld"

--- a/roles/common/tasks/rhel7_repos.yml
+++ b/roles/common/tasks/rhel7_repos.yml
@@ -4,4 +4,3 @@
 
 - name: Enable RHEL7 Extra Repo
   command: "subscription-manager repos --enable rhel-7-server-extras-rpms"
-  when: not is_atomic


### PR DESCRIPTION
Since RHEL Atomic has all the necessary bits installed by default, it is
not necessary for the host to register via 'subman' or include the Extra
repos.

Signed-off-by: Micah Abbott <miabbott@redhat.com>